### PR TITLE
Prevent PlayerPortal to the Nether

### DIFF
--- a/src/com/bergerkiller/bukkit/mw/MWPlayerListener.java
+++ b/src/com/bergerkiller/bukkit/mw/MWPlayerListener.java
@@ -19,6 +19,7 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerPortalEvent;
 
 public class MWPlayerListener extends PlayerListener {
 	
@@ -32,6 +33,11 @@ public class MWPlayerListener extends PlayerListener {
 			--maxwidth;
 			if (maxwidth <= 0) return false;
 		}
+	}
+	
+	public void onPlayerPortal(PlayerPortalEvent event) {
+		if(Portal.get(event.getFrom(), 5)!=null)
+			event.setCancelled(true);
 	}
 	
 	@Override

--- a/src/com/bergerkiller/bukkit/mw/MyWorlds.java
+++ b/src/com/bergerkiller/bukkit/mw/MyWorlds.java
@@ -61,6 +61,7 @@ public class MyWorlds extends JavaPlugin {
         pm.registerEvent(Event.Type.PLAYER_JOIN, playerListener, Priority.Monitor, this);
         pm.registerEvent(Event.Type.PLAYER_QUIT, playerListener, Priority.Monitor, this);
         pm.registerEvent(Event.Type.PLAYER_CHANGED_WORLD, playerListener, Priority.Monitor, this);
+        pm.registerEvent(Event.Type.PLAYER_PORTAL, playerListener, Priority.High, this);
         pm.registerEvent(Event.Type.PLAYER_INTERACT, playerListener, Priority.Lowest, this);
         pm.registerEvent(Event.Type.SIGN_CHANGE, blockListener, Priority.Normal, this);  
         pm.registerEvent(Event.Type.WORLD_LOAD, worldListener, Priority.Monitor, this);  


### PR DESCRIPTION
My patch prevents MyWorlds portals from being used as Nether Portals. This was possible for players that didn't have permission to use a portal.
